### PR TITLE
fix(test/char): fixing typo on the error message

### DIFF
--- a/test/char/test_isalnum.c
+++ b/test/char/test_isalnum.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_isalnum(c) != isalnum(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_isalnum(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_isalnum(c),
 				isalnum(c), RESET);
 			exit(1);
 		}

--- a/test/char/test_isalpha.c
+++ b/test/char/test_isalpha.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_isalpha(c) != isalpha(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_isalpha(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_isalpha(c),
 				isalpha(c), RESET);
 			exit(1);
 		}

--- a/test/char/test_isascii.c
+++ b/test/char/test_isascii.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_isascii(c) != isascii(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_isascii(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_isascii(c),
 				isascii(c), RESET);
 			exit(1);
 		}

--- a/test/char/test_isdigit.c
+++ b/test/char/test_isdigit.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_isdigit(c) != isdigit(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_isdigit(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_isdigit(c),
 				isdigit(c), RESET);
 			exit(1);
 		}

--- a/test/char/test_isprint.c
+++ b/test/char/test_isprint.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_isprint(c) != isprint(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_isprint(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_isprint(c),
 				isprint(c), RESET);
 			exit(1);
 		}

--- a/test/char/test_tolower.c
+++ b/test/char/test_tolower.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_tolower(c) != tolower(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_tolower(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_tolower(c),
 				tolower(c), RESET);
 			exit(1);
 		}

--- a/test/char/test_toupper.c
+++ b/test/char/test_toupper.c
@@ -25,7 +25,7 @@ int	main(void)
 	{
 		if (ft_toupper(c) != toupper(c))
 		{
-			printf("%s✘ Found %i, excepted %i%s\n", CLR_RED, ft_toupper(c),
+			printf("%s✘ Found %i, expected %i%s\n", CLR_RED, ft_toupper(c),
 				toupper(c), RESET);
 			exit(1);
 		}


### PR DESCRIPTION
This pull request makes a minor but important correction to the error messages in several character test files. The word "excepted" has been replaced with the correct term "expected" in the output printed when a test fails. This improves the clarity and professionalism of the test output.

Test output improvements:

* Corrected typo in error messages from "excepted" to "expected" in the following test files:
  * `test/char/test_isalnum.c`
  * `test/char/test_isalpha.c`
  * `test/char/test_isascii.c`
  * `test/char/test_isdigit.c`
  * `test/char/test_isprint.c`
  * `test/char/test_tolower.c`
  * `test/char/test_toupper.c`